### PR TITLE
Fix duplicate login error message and center password toggle icon

### DIFF
--- a/Portal.Web/Views/Login/Index.cshtml
+++ b/Portal.Web/Views/Login/Index.cshtml
@@ -16,7 +16,7 @@
             @Html.AntiForgeryToken()
             <h2 id="login-title">Bem-vindo</h2>
 
-            @Html.ValidationSummary(false, "", new { @class = "form-summary text-danger" })
+            @Html.ValidationSummary(true, "", new { @class = "form-summary text-danger" })
 
             <div class="form-group has-tooltip">
                 @Html.LabelFor(m => m.Email, new { @class = "form-label" })

--- a/Portal.Web/wwwroot/css/login.css
+++ b/Portal.Web/wwwroot/css/login.css
@@ -145,7 +145,7 @@ body {
 .toggle-password {
     position: absolute;
     right: .5rem;
-    top: 2.35rem;
+    top: 50%;
     transform: translateY(-50%);
     background: transparent;
     border: 0;


### PR DESCRIPTION
## Summary
- ensure the login validation summary no longer duplicates field-level errors
- center the password visibility toggle icon within the password input

## Testing
- dotnet run --project Portal.Web *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ac63c6508333ba45f3b677ac82f8