### PR TITLE
Remover constantes de administrador e usar appsettings

### DIFF
--- a/Portal.Web/Const/UserConst.cs
+++ b/Portal.Web/Const/UserConst.cs
@@ -1,9 +1,0 @@
-﻿namespace GestaoSaudeIdosos.Web.Const
-{
-    public class UserConst
-    {
-        public const string AdminName = "Administrador";
-        public const string AdminPassword = "Admin@2025";
-        public const string AdminEmail = "admin@gmail.com";
-    }
-}

--- a/Portal.Web/Controllers/LoginController.cs
+++ b/Portal.Web/Controllers/LoginController.cs
@@ -1,21 +1,24 @@
 using System.Security.Claims;
 using GestaoSaudeIdosos.Application.Interfaces;
-using GestaoSaudeIdosos.Web.Const;
 using GestaoSaudeIdosos.Web.ViewModels;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using GestaoSaudeIdosos.Web.Options;
+using Microsoft.Extensions.Options;
 
 namespace GestaoSaudeIdosos.Web.Controllers
 {
     public class LoginController : Controller
     {
         private readonly IUsuarioAppService _service;
+        private readonly AdminUserOptions _adminUserOptions;
 
-        public LoginController(IUsuarioAppService service)
+        public LoginController(IUsuarioAppService service, IOptions<AdminUserOptions> adminUserOptions)
         {
             _service = service;
+            _adminUserOptions = adminUserOptions.Value;
         }
 
         [HttpGet]
@@ -30,11 +33,15 @@ namespace GestaoSaudeIdosos.Web.Controllers
             if (!ModelState.IsValid)
                 return View(model);
 
-            var isAdmin = model.IsAdminGlobal();
             var email = model.Email?.Trim() ?? string.Empty;
+            var adminEmail = _adminUserOptions.Email?.Trim() ?? string.Empty;
+            var isAdmin =
+                !string.IsNullOrWhiteSpace(adminEmail) &&
+                string.Equals(email, adminEmail, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(model.Senha, _adminUserOptions.Password);
 
-            var usuario = isAdmin 
-                ? new Domain.Entities.Usuario() { UsuarioId = 0, NomeCompleto = UserConst.AdminName, Email = UserConst.AdminEmail, Ativo = true} 
+            var usuario = isAdmin
+                ? new Domain.Entities.Usuario() { UsuarioId = 0, NomeCompleto = _adminUserOptions.Name, Email = _adminUserOptions.Email, Ativo = true }
                 : _service.AsQueryable().FirstOrDefault(f => f.Email == email);
 
             if (usuario is null || (usuario is not null && !usuario.Ativo))

--- a/Portal.Web/Options/AdminUserOptions.cs
+++ b/Portal.Web/Options/AdminUserOptions.cs
@@ -1,0 +1,9 @@
+namespace GestaoSaudeIdosos.Web.Options
+{
+    public class AdminUserOptions
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/Portal.Web/Program.cs
+++ b/Portal.Web/Program.cs
@@ -2,6 +2,7 @@ using GestaoSaudeIdosos.Application;
 using GestaoSaudeIdosos.Domain;
 using GestaoSaudeIdosos.Infra;
 using GestaoSaudeIdosos.Web.Filters;
+using GestaoSaudeIdosos.Web.Options;
 using GestaoSaudeIdosos.Web.Services;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
@@ -13,6 +14,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddInfraServices(builder.Configuration);
 builder.Services.AddApplicationServices();
 builder.Services.AddDomainServices();
+builder.Services.Configure<AdminUserOptions>(builder.Configuration.GetSection("AdminUser"));
 
 builder.Services.AddScoped<TempDataAlertFilter>();
 builder.Services.AddScoped<IImagemStorageService, ImagemStorageService>();

--- a/Portal.Web/ViewModels/LoginViewModel.cs
+++ b/Portal.Web/ViewModels/LoginViewModel.cs
@@ -11,7 +11,6 @@ namespace GestaoSaudeIdosos.Web.ViewModels
         [Required(ErrorMessage = "A senha é obrigatória.")]
         [DataType(DataType.Password)]
         public string Senha { get; set; } = string.Empty;
-
-        internal bool IsAdminGlobal() => Email.Trim().ToLower() == Const.UserConst.AdminEmail.ToLower() && Senha == Const.UserConst.AdminPassword;
     }
 }
+

--- a/Portal.Web/appsettings.json
+++ b/Portal.Web/appsettings.json
@@ -9,5 +9,10 @@
   "ConnectionStrings": {
     "DatabaseSqlServer": "false",
     "DefaultConnection": ""
+  },
+  "AdminUser": {
+    "Name": "Administrador",
+    "Password": "Admin@2025",
+    "Email": "admin@gmail.com"
   }
 }


### PR DESCRIPTION
## Summary
- adiciona a seção AdminUser no appsettings e um objeto de opções tipado
- injeta as novas opções no LoginController e migra a validação do administrador para usar configuração
- remove a classe de constantes e o helper do LoginViewModel associados ao administrador global

## Testing
- dotnet test *(falhou: comando não encontrado no ambiente de execução)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e93a7d19883338ca5de29c3a72f67)